### PR TITLE
Support gpus on slurm

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,9 +3,9 @@ Changelog
 ==========
 
 + Support for ``slurm_partition`` runtime attribute.
-+ Support for ``gpu`` and ``num_gpu`` runtime attributes. The ``gpu`` runtime
++ Support for ``gpu`` and ``gpuCount`` runtime attributes. The ``gpu`` runtime
   attribute is a boolean that indicates whether the task requires a GPU.  The
-  ``num_gpu`` runtime attribute is an integer that indicates the number of GPUs
+  ``gpuCount`` runtime attribute is an integer that indicates the number of GPUs
   required by the task.
 + Support for ``slurm_constraint`` runtime attribute.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,12 @@
 Changelog
 ==========
 
-.. Newest changes should be on top.
-
-.. This document is user facing. Please word the changes in such a way
-.. that users understand how the changes affect the new version.
++ Support for ``slurm_partition`` runtime attribute.
++ Support for ``gpu`` and ``num_gpu`` runtime attributes. The ``gpu`` runtime
+  attribute is a boolean that indicates whether the task requires a GPU.  The
+  ``num_gpu`` runtime attribute is an integer that indicates the number of GPUs
+  required by the task.
++ Support for ``slurm_constraint`` runtime attribute.
 
 version 0.1.0
 ----------------------------

--- a/src/miniwdl_slurm/__init__.py
+++ b/src/miniwdl_slurm/__init__.py
@@ -80,9 +80,9 @@ class SlurmSingularity(SingularityContainer):
             slurm_partition = runtime_eval["slurm_partition"].coerce(Type.String()).value
             self.runtime_values["slurm_partition"] = slurm_partition
 
-        if "num_gpu" in runtime_eval:
-            num_gpu = max(1, runtime_eval["num_gpu"].coerce(Type.Int()).value)
-            self.runtime_values["num_gpu"] = num_gpu
+        if "gpuCount" in runtime_eval:
+            gpuCount = max(1, runtime_eval["gpuCount"].coerce(Type.Int()).value)
+            self.runtime_values["gpuCount"] = gpuCount
 
         if "slurm_constraint" in runtime_eval:
             slurm_constraint = runtime_eval["slurm_constraint"].coerce(Type.String()).value
@@ -112,8 +112,8 @@ class SlurmSingularity(SingularityContainer):
 
         gpu = self.runtime_values.get("gpu", None)
         if gpu:
-            num_gpu = self.runtime_values.get("num_gpu", 1)
-            srun_args.extend(["--gres", f"gpu:{num_gpu}"])
+            gpuCount = self.runtime_values.get("gpuCount", 1)
+            srun_args.extend(["--gres", f"gpu:{gpuCount}"])
 
         time_minutes = self.runtime_values.get("time_minutes", None)
         if time_minutes is not None:


### PR DESCRIPTION
- added runtime variable `slurm_partition` (string)
- added runtime variable `num_gpu` (int) 
- if `gpu` is true, `max(1,num_gpu)` gpus will be requested
- added runtime variable `constraint` (string)


### Checklist
- [x] Pull request details were added to CHANGELOG.rst

I can change `num_gpu` to `gpuCount` if preferred.

I've tested all of these internally and can build a test if that would help.