### PR TITLE
Add gpuType runtime attribute

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,12 @@ Changelog
 
 version 0.3.0-dev
 ----------------------------
-+ Use `sbatch --wait` instead of `srun` to prevent issues with batch submitted
++ Use ``sbatch --wait`` instead of ``srun`` to prevent issues with batch submitted
   miniwdl runs.
-+ Always set `--ntasks 1`` to prevent multiple tasks being spawned.
-+ Add support for a ``slurm_gpu_partition`` runtime attribute.
++ Always set ``--ntasks 1`` to prevent multiple tasks being spawned.
++ Add support for a ``gpuType`` runtime attribute to specify the type of GPU required.
++ Add support for a ``slurm_partition_gpu`` runtime attribute.
++ Add support for ``slurm_account`` and ``slurm_account_gpu`` runtime attributes.
 
 
 version 0.2.0

--- a/src/miniwdl_slurm/__init__.py
+++ b/src/miniwdl_slurm/__init__.py
@@ -101,6 +101,10 @@ class SlurmSingularity(SingularityContainer):
             gpuCount = max(1, runtime_eval["gpuCount"].coerce(Type.Int()).value)
             self.runtime_values["gpuCount"] = gpuCount
 
+        if "gpuType" in runtime_eval:
+            gpuType = runtime_eval["gpuType"].coerce(Type.String()).value
+            self.runtime_values["gpuType"] = gpuType
+
         if "slurm_constraint" in runtime_eval:
             slurm_constraint = runtime_eval["slurm_constraint"].coerce(
                 Type.String()).value
@@ -126,26 +130,31 @@ class SlurmSingularity(SingularityContainer):
             "--ntasks", "1",
         ]
 
-        gpu = self.runtime_values.get("gpu", None)
-        if gpu:
-            gpuCount = self.runtime_values.get("gpuCount", 1)
+        gpuCount = self.runtime_values.get("gpuCount", None)
+        gpuType = self.runtime_values.get("gpuType", None)
+        if gpuCount is not None and gpuType is not None:
+            sbatch_args.extend(["--gres", f"gpu:{gpuType}:{gpuCount}"])
+        elif gpuCount is not None:
+            # If no gpuType is given, use the default GPU type.
             sbatch_args.extend(["--gres", f"gpu:{gpuCount}"])
+
         account = self.runtime_values.get("slurm_account", None)
         account_gpu = self.runtime_values.get("slurm_account_gpu", None)
-        if gpu and account_gpu is not None:
+        if gpuCount is not None and account_gpu is not None:
             sbatch_args.extend(["--account", account_gpu])
         elif account is not None:
             sbatch_args.extend(["--account", account])
+
         partition = self.runtime_values.get("slurm_partition", None)
         partition_gpu = self.runtime_values.get("slurm_partition_gpu", None)
-        if gpu and partition_gpu is not None:
+        if gpuCount is not None and partition_gpu is not None:
             sbatch_args.extend(["--partition", partition_gpu])
         elif partition is not None:
             sbatch_args.extend(["--partition", partition])
 
         cpu = self.runtime_values.get("cpu", None)
         if cpu is not None:
-            sbatch_args.extend(["--mincpu", str(cpu)])
+            sbatch_args.extend(["--cpus-per-task", str(cpu)])
 
         memory = self.runtime_values.get("memory_reservation", None)
         if memory is not None:


### PR DESCRIPTION
- added `String gpuType` attribute
- rather than using the `Boolean gpu` runtime attribute to indicate that GPUs should be requested, use `gpuCount is not None`
- if `gpuType` is specified in runtime defaults or task specific runtime attributes, add `--gres gpu:{gpuType}:{gpuCount}`, otherwise add `--gres gpu:{gpuCount}`
- Updated changelog

Unrelated, reverting `--mincpu` to `--cpus-per-task` as described in https://github.com/miniwdl-ext/miniwdl-slurm/commit/d2c58c5e240f7952ba1ca887ce14bd4f3afb480a#commitcomment-158445188

Thanks @RhettRautsaw for testing.

### Checklist
- [x] Pull request details were added to CHANGELOG.rst
