### PR TITLE
Allow providing a dynamic process to select queue.

### DIFF
--- a/src/miniwdl_slurm/__init__.py
+++ b/src/miniwdl_slurm/__init__.py
@@ -173,6 +173,13 @@ class SlurmSingularity(SingularityContainer):
             extra_args = self.cfg.get("slurm", "extra_args")
             if extra_args is not None:
                 sbatch_args.extend(shlex.split(extra_args))
+
+            dynamic_partition = self.cfg.get("slurm", "dynamic_partition", None)
+            if dynamic_partition is not None:
+                import subprocess
+                env = {f"runtime_value_{str(k)}".upper(): str(v) for k, v in self.runtime_values.items()}
+                srun_args.extend(subprocess.check_output(dynamic_partition, env=env).decode('utf-8').split())
+
         # This is a script that simply executes all the following arguments.
         exec_script = os.path.join(os.path.dirname(__file__), "scripts",
                                    "exec_script.sh")

--- a/src/miniwdl_slurm/__init__.py
+++ b/src/miniwdl_slurm/__init__.py
@@ -174,8 +174,8 @@ class SlurmSingularity(SingularityContainer):
             if extra_args is not None:
                 sbatch_args.extend(shlex.split(extra_args))
 
-            dynamic_partition = self.cfg.get("slurm", "dynamic_partition", None)
-            if dynamic_partition is not None:
+            dynamic_partition = self.cfg.get("slurm", "dynamic_partition", False)
+            if dynamic_partition:
                 import subprocess
                 env = {f"runtime_value_{str(k)}".upper(): str(v) for k, v in self.runtime_values.items()}
                 srun_args.extend(subprocess.check_output(dynamic_partition, env=env).decode('utf-8').split())


### PR DESCRIPTION
I have the following situation: a variety of very heterogeneous jobs, some need the high memory partition, some could run sooner on a 'short' partition.

```
$ sbatch --partition short,all,highmem --time 2:0:0 --wrap pwd
sbatch: error: Batch job submission failed: Requested time limit is invalid (missing or exceeds some limit)
```

In other job systems like nextflow, people write things like:

```
memory { 100.MB * task.attempt }
time { 5.minute * task.attempt }
queue { entries > 100 ? 'long' : 'short' }
```

deciding which queue to send something to based on job information.

I would like the ability to do that, in some way or form, without having to hardcore cluster specific partition names in otherwise reusable WDL tasks.

So I'm proposing one such way in this PR, whereby a program can be provided which will be executed before submitting each job, and should return some `srun` arguments.

Here is an example script that could be used:

```
#!/usr/bin/env bash
if (( MINIWDL_RUNTIME_VALUE_TIME_MINUTES < 59 )); then
        echo "--partition short"
else
        echo "--partition all,highmem"
fi
```

which could be used with a miniwdl.cfg like:

```
[slurm]
# extra arguments passed to the srun command (optional).
dynamic_partition=/home/esrasche/bin/partition
```