### PR TITLE
Extra args

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ version 0.5.0
 ----------------------------
 + Add support for a ``dynamic_partition`` attribute to supply ``sbatch``
   arguments based on job submission parameters.
++ Safely handle case where ``extra_args`` is not set.
 
 version 0.4.0
 ----------------------------

--- a/src/miniwdl_slurm/__init__.py
+++ b/src/miniwdl_slurm/__init__.py
@@ -170,8 +170,8 @@ class SlurmSingularity(SingularityContainer):
             sbatch_args.extend(["--constraint", slurm_constraint])
 
         if self.cfg.has_section("slurm"):
-            extra_args = self.cfg.get("slurm", "extra_args")
-            if extra_args is not None:
+            extra_args = self.cfg.get("slurm", "extra_args", "")
+            if extra_args:
                 sbatch_args.extend(shlex.split(extra_args))
 
             partition_rules = self.cfg.get_list("slurm", "dynamic_partition", [])


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to CHANGELOG.rst

I believe this is required now, before if you had a slurm section of course you'd have the extra args, otherwise why have the section. but now that there are options, we need to have a safer default value. Without the `None` this is treated as mandatory, and miniwdl refuses to execute

```
2025-07-07 13:34:29.104 wdl.w:x.t:call-low ERROR task A (main.wdl Ln 3 Col 1) failed :: dir: "/home/user/kg/miniwdl-dev/20250707_133428_x/call-low", error: "ConfigMissing", message: "missing config option [slurm] extra_args", traceback: ["Traceback (most recent call last):
  File \"/home/user/kg/miniwdl-dev/.direnv/python-3.13/lib64/python3.13/site-packages/WDL/runtime/task.py\", line 211, in run_local_task
    _try_task(cfg, task, logger, container, command, terminating)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/home/user/kg/miniwdl-dev/.direnv/python-3.13/lib64/python3.13/site-packages/WDL/runtime/task.py\", line 612, in _try_task
    return container.run(logger, command)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File \"/home/user/kg/miniwdl-dev/.direnv/python-3.13/lib64/python3.13/site-packages/WDL/runtime/task_container.py\", line 323, in run
    exit_code = self._run(logger, terminating, command)
  File \"/home/user/kg/miniwdl-dev/.direnv/python-3.13/lib64/python3.13/site-packages/miniwdl_slurm/__init__.py\", line 208, in _run
    return super()._run(logger, terminating, command)
           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/home/user/kg/miniwdl-dev/.direnv/python-3.13/lib64/python3.13/site-packages/WDL/runtime/backend/cli_subprocess.py\", line 93, in _run
    invocation = self._run_invocation(logger, cleanup, image) + [
                 ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/home/user/kg/miniwdl-dev/.direnv/python-3.13/lib64/python3.13/site-packages/miniwdl_slurm/__init__.py\", line 194, in _run_invocation
    slurm_invocation = self._slurm_invocation()
  File \"/home/user/kg/miniwdl-dev/.direnv/python-3.13/lib64/python3.13/site-packages/miniwdl_slurm/__init__.py\", line 173, in _slurm_invocation
    print('xxxxx', self.cfg.get(\"slurm\", \"extra_args\"))
                   ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File \"/home/user/kg/miniwdl-dev/.direnv/python-3.13/lib64/python3.13/site-packages/WDL/runtime/config.py\", line 195, in get
    raise ConfigMissing(f\"missing config option [{section}] {key}\")
WDL.runtime.config.ConfigMissing: missing config option [slurm] extra_args"]
```

This occurs due to the following .. interesting behaviour:

```
(Pdb) self.cfg.get_list('slurm', 'asdf', [])
[]
(Pdb) self.cfg.get('slurm', 'asdf', [])
[]
(Pdb) self.cfg.get('slurm', 'asdf', None)
*** WDL.runtime.config.ConfigMissing: missing config option [slurm] asdf
(Pdb) self.cfg.get('slurm', 'asdf', "")
''
```

note that None (a sensible default), throws an exception, unlike the other options. We could check `has_option`, but, I've just defaulted to `""` and then checked `if extra_args` to catch if someone's decided to set it to an empty string for some reason.